### PR TITLE
Added the ability to delete sticky using IWallItem

### DIFF
--- a/Xabbo.Scripter.Common/Scripting/Globals/G.Sticky.cs
+++ b/Xabbo.Scripter.Common/Scripting/Globals/G.Sticky.cs
@@ -77,8 +77,8 @@ namespace Xabbo.Scripter.Scripting
         /// </summary>
         public void DeleteSticky(IWallItem sticky)
         {
-            var stickies = new List<int> { 4221, 4531, 4220, 4533, 4540, 4557 };
-            if (stickies.Contains(sticky.Kind)) DeleteWallItem(sticky.Id);
+            var validStickyKinds = new List<int> { 4221, 4531, 4220, 4533, 4540, 4557 };
+            if (validStickyKinds.Contains(sticky.Kind)) DeleteWallItem(sticky.Id);
             else throw new Exception("Selected wallitem is not a sticky");
         }
 

--- a/Xabbo.Scripter.Common/Scripting/Globals/G.Sticky.cs
+++ b/Xabbo.Scripter.Common/Scripting/Globals/G.Sticky.cs
@@ -71,6 +71,16 @@ namespace Xabbo.Scripter.Scripting
         /// Deletes the specified sticky.
         /// </summary>
         public void DeleteSticky(Sticky sticky) => DeleteWallItem(sticky.Id);
+        
+        /// <summary>
+        /// Deletes the specified wallitem if its a sticky.
+        /// </summary>
+        public void DeleteSticky(IWallItem sticky)
+        {
+            var stickies = new List<int> { 4221, 4531, 4220, 4533, 4540, 4557 };
+            if (stickies.Contains(sticky.Kind)) DeleteWallItem(sticky.Id);
+            else throw new Exception("Selected wallitem is not a sticky");
+        }
 
     }
 }


### PR DESCRIPTION
Basically removes the need to first do GetSticky before you can do DeleteSticky, because GetSticky has a really high rate limit so it won't let you delete stickies really fast

I also added a check just in case to see if the wallitem is actually a sticky so it won't send any invalid packets